### PR TITLE
Configure countdown to be smooth, rather than tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This plugin provides a simple circular countdown timer with customizable setting
 
 ```javascript
 {
-  radius: 15.5,                    // radius of arc
+	radius: 15.5,                    // radius of arc
 	strokeStyle: "#477050",          // the color of the stroke
 	strokeWidth: undefined,          // the stroke width, dynamically calulated if omitted in options
 	fillStyle: "#8ac575",            // the fill color
@@ -59,8 +59,9 @@ This plugin provides a simple circular countdown timer with customizable setting
 	fontWeight: 700,                 // the font weight
 	autostart: true,                 // start the countdown automatically
 	seconds: 10,                     // the number of seconds to count down
-	label: ["second", "seconds"],   // the label to use or false if none, first is singular form, second is plural
+	label: ["second", "seconds"],    // the label to use or false if none, first is singular form, second is plural
 	startOverAfterAdding: true,      // Start the timer over after time is added with addSeconds
+	smooth: false,                   // update the ticks every 16ms when true
 	onComplete: function () {}
 }
 ```

--- a/src/jquery.countdown360.js
+++ b/src/jquery.countdown360.js
@@ -13,6 +13,7 @@
       seconds: 10,                     // the number of seconds to count down
       label: ["second", "seconds"],    // the label to use or false if none
       startOverAfterAdding: true,      // Start the timer over after time is added with addSeconds
+      smooth: false,                   // should the timer be smooth or stepping
       onComplete: function () {}
     };
 
@@ -31,7 +32,7 @@
     {
     
       var timeRemaining = this._secondsLeft(this.getElapsedTime());
-      return  timeRemaining;
+      return timeRemaining;
     },
     getElapsedTime: function()
     {
@@ -59,7 +60,11 @@
       this.startedAt = new Date();
       this._drawCountdownShape(Math.PI*3.5, true);
       this._drawCountdownLabel(0);
-      this.interval = setInterval(jQuery.proxy(this._draw, this), 1000);
+      var timerInterval = 1000;
+      if (this.settings.smooth) {
+        timerInterval = 16;
+      }
+      this.interval = setInterval(jQuery.proxy(this._draw, this), timerInterval);
     },
 
     stop: function (cb) {
@@ -135,8 +140,9 @@
     },
 
     _draw: function () {
-      var secondsElapsed = Math.round((new Date().getTime() - this.startedAt.getTime())/1000),
-          endAngle = (Math.PI*3.5) - (((Math.PI*2)/this.settings.seconds) * secondsElapsed);
+      var millisElapsed = new Date().getTime() - this.startedAt.getTime();
+      var secondsElapsed = Math.floor((millisElapsed)/1000);
+        endAngle = (Math.PI*3.5) - (((Math.PI*2)/(this.settings.seconds * 1000)) * millisElapsed);
       this._clearRect();
       this._drawCountdownShape(Math.PI*3.5, false);
       if (secondsElapsed < this.settings.seconds) {

--- a/src/jquery.countdown360.js
+++ b/src/jquery.countdown360.js
@@ -140,8 +140,9 @@
     },
 
     _draw: function () {
-      var millisElapsed = new Date().getTime() - this.startedAt.getTime();
-      var secondsElapsed = Math.floor((millisElapsed)/1000);
+      var millisElapsed, secondsElapsed;
+      millisElapsed = new Date().getTime() - this.startedAt.getTime();
+      secondsElapsed = Math.floor((millisElapsed)/1000);
         endAngle = (Math.PI*3.5) - (((Math.PI*2)/(this.settings.seconds * 1000)) * millisElapsed);
       this._clearRect();
       this._drawCountdownShape(Math.PI*3.5, false);


### PR DESCRIPTION
### Issue
I require a countdown timer with smooth transition rather than ticking

### Solution
Added a new property `smooth` which when set to true recalculates the stroke every 16ms. It is set to false by default