### PR TITLE
Add clockwise minuteformat seocondsremaining

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 
+demo.html

--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ This plugin provides a simple circular countdown timer with customizable setting
 	fontWeight: 700,                 // the font weight
 	autostart: true,                 // start the countdown automatically
 	seconds: 10,                     // the number of seconds to count down
-	timeformat: 'SS',                // the time format
+	remainingSeconds: undefined,     // optional number of seconds to skip ahead on start, if omitted timer will start at the value of 'seconds'	
+	timeformat: 'SS',                // the time format, use "MMSS" for MM:SS format (e.g.: 07:21) 
 	label: ["second", "seconds"],    // the label to use or false if none, first is singular form, second is plural
 	startOverAfterAdding: true,      // Start the timer over after time is added with addSeconds
 	smooth: false,                   // update the ticks every 16ms when true
+	clockwise: false,                // clockwise removal of stroke
 	onComplete: function () {}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This plugin provides a simple circular countdown timer with customizable setting
 	fontWeight: 700,                 // the font weight
 	autostart: true,                 // start the countdown automatically
 	seconds: 10,                     // the number of seconds to count down
+	timeformat: 'SS',                // the time format
 	label: ["second", "seconds"],    // the label to use or false if none, first is singular form, second is plural
 	startOverAfterAdding: true,      // Start the timer over after time is added with addSeconds
 	smooth: false,                   // update the ticks every 16ms when true

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This plugin provides a simple circular countdown timer with customizable setting
 	label: ["second", "seconds"],    // the label to use or false if none, first is singular form, second is plural
 	startOverAfterAdding: true,      // Start the timer over after time is added with addSeconds
 	smooth: false,                   // update the ticks every 16ms when true
-	clockwise: false,                // clockwise removal of stroke
+	clockwise: false,                // clockwise removal of stroke 
 	onComplete: function () {}
 }
 ```

--- a/src/jquery.countdown360.js
+++ b/src/jquery.countdown360.js
@@ -11,6 +11,7 @@
       fontWeight: 700,                 // the font weight
       autostart: true,                 // start the countdown automatically
       seconds: 10,                     // the number of seconds to count down
+      timeformat: 'SS',                // the time format
       label: ["second", "seconds"],    // the label to use or false if none
       startOverAfterAdding: true,      // Start the timer over after time is added with addSeconds
       smooth: false,                   // should the timer be smooth or stepping
@@ -124,12 +125,27 @@
       this.pen.fillStyle = this.settings.fillStyle;
       this.pen.fillText(secondsLeft + 1, x, y);
       this.pen.fillStyle  = this.settings.fontColor;
-      this.pen.fillText(secondsLeft, x, y);
+      this.pen.fillText(this._timeFormat(secondsLeft, this.settings.timeformat), x, y);
       if (drawLabel) {
         this.pen.font = "normal small-caps " + (this.settings.fontSize/3) + "px " + this.settings.fontFamily;
         this.pen.fillText(label, this.settings.width/2, this.settings.height/2 + (this.settings.fontSize/2.2));
       }
     },
+    
+    _timeFormat: function (secondsLeft, format) {
+      switch(format) {
+      case 'MMSS':
+        var minutes = Math.floor(secondsLeft / 60);
+        var seconds = secondsLeft - (minutes * 60);
+        if (minutes < 10) {minutes = "0"+minutes;}
+        if (seconds < 10) {seconds = "0"+seconds;}
+        return minutes+':'+seconds;
+      case 'SS':
+        return secondsLeft;
+      default:
+        return secondsLeft;     
+      }
+    },    
 
     _drawCountdownShape: function (endAngle, drawStroke) {
       this.pen.fillStyle = this.settings.fillStyle;


### PR DESCRIPTION
This adds these three options/features:

``` javascript
{
// defaults shown
remainingSeconds: undefined,     // optional number of seconds to skip ahead on start, if omitted timer will start at the value of 'seconds'    
timeformat: 'SS',                // the time format, use "MMSS" for MM:SS format (e.g.: 07:21) 
clockwise: false                // clockwise removal of stroke 
}
```

As per feature request in issues:
- remainingSeconds: [https://github.com/johnschult/jquery.countdown360/issues/12](url)
- 'clockwise' code: credit goes to **HiTechMagic** : [https://github.com/johnschult/jquery.countdown360/issues/3](url)
